### PR TITLE
Added properties to access point and disk shader

### DIFF
--- a/Assets/Pcx/PointCloudRenderer.cs
+++ b/Assets/Pcx/PointCloudRenderer.cs
@@ -42,6 +42,16 @@ namespace Pcx
 
         #region Internal resources
 
+        public Shader pointShader {
+            get { return _pointShader; }
+            set { _pointShader = value; }
+        }
+
+        public Shader diskShader {
+            get { return _diskShader; }
+            set { _diskShader = value; }
+        }
+
         [SerializeField, HideInInspector] Shader _pointShader;
         [SerializeField, HideInInspector] Shader _diskShader;
 


### PR DESCRIPTION
I've extended your project to render a point cloud received in realtime from ROS. During the creation of that point cloud the point and disk shaders need to be set programmatically. To do so, two public properties are added to the PointCloudRenderer.